### PR TITLE
Adding CORS parameters

### DIFF
--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -19,7 +19,8 @@ http:
   enabled: ${HTTP_ENABLE}
   compression: true
   cors:
-    enabled: ${HTTP_CORS_ENABLE}
+    enabled: ${HTTP_CORS_ENABLED}
+    allow-origin: ${HTTP_CORS_ALLOW_ORIGIN}
 
 cloud:
   kubernetes:

--- a/run.sh
+++ b/run.sh
@@ -12,9 +12,10 @@ export CLUSTER_NAME=${CLUSTER_NAME:-elasticsearch-default}
 export NODE_MASTER=${NODE_MASTER:-true}
 export NODE_DATA=${NODE_DATA:-true}
 export HTTP_ENABLE=${HTTP_ENABLE:-true}
-export HTTP_CORS_ENABLE=${HTTP_CORS_ENABLE:-true}
+export HTTP_CORS_ENABLED=${HTTP_CORS_ENABLED:-true}
 export NETWORK_HOST=${NETWORK_HOST:-_site_}
 export MULTICAST=${MULTICAST:-true}
+export HTTP_CORS_ALLOW_ORIGIN=${HTTP_CORS_ALLOW_ORIGIN:-*}
 
 # Kubernetes stuff
 export NAMESPACE=${NAMESPACE:-default}


### PR DESCRIPTION
Thanks for the great docker image! 

I needed CORS in a deployment so I added HTTP_CORS_ALLOW_ORIGIN & renamed HTTP_CORS_ENABLE -> HTTP_CORS_ENABLED per https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html

I'm not sure about the default values but I tested in google container engine & was able to run CORS requests. 