### PR TITLE
Implement TLS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pires/docker-elasticsearch:5.0.0
+FROM quay.io/pires/docker-elasticsearch:2.4.1
 
 MAINTAINER pjpires@gmail.com
 
@@ -6,9 +6,9 @@ MAINTAINER pjpires@gmail.com
 ADD do_not_use.yml /elasticsearch/config/elasticsearch.yml
 
 # Install Elasticsearch plug-ins
-RUN /elasticsearch/bin/elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:5.0.0
-RUN /elasticsearch/bin/elasticsearch-plugin install lmenezes/elasticsearch-kopf
-RUN /elasticsearch/bin/elasticsearch-plugin install com.floragunn/search-guard-ssl/2.4.1.16
+RUN /elasticsearch/bin/plugin install io.fabric8/elasticsearch-cloud-kubernetes/2.4.1
+RUN /elasticsearch/bin/plugin install lmenezes/elasticsearch-kopf
+RUN /elasticsearch/bin/plugin install com.floragunn/search-guard-ssl/2.4.1.16
 
 # Override elasticsearch.yml config, otherwise plug-in install will fail
 ADD elasticsearch.yml /elasticsearch/config/elasticsearch.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pires/docker-elasticsearch:2.4.1
+FROM quay.io/pires/docker-elasticsearch:5.0.0
 
 MAINTAINER pjpires@gmail.com
 
@@ -6,17 +6,12 @@ MAINTAINER pjpires@gmail.com
 ADD do_not_use.yml /elasticsearch/config/elasticsearch.yml
 
 # Install Elasticsearch plug-ins
-RUN /elasticsearch/bin/plugin install io.fabric8/elasticsearch-cloud-kubernetes/2.4.1
-RUN /elasticsearch/bin/plugin install lmenezes/elasticsearch-kopf
-RUN /elasticsearch/bin/plugin install com.floragunn/search-guard-ssl/2.4.1.16
+RUN /elasticsearch/bin/elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:5.0.0
+RUN /elasticsearch/bin/elasticsearch-plugin install lmenezes/elasticsearch-kopf
+RUN /elasticsearch/bin/elasticsearch-plugin install com.floragunn/search-guard-ssl/2.4.1.16
 
 # Override elasticsearch.yml config, otherwise plug-in install will fail
 ADD elasticsearch.yml /elasticsearch/config/elasticsearch.yml
-
-# Copy in SSL Certs
-# NOTE: For a Kubernetes based deployment, make these secrets which are provided dynamically
-ADD scripts/node-keystore.jks /elasticsearch/config/node-keystore.jks
-ADD scripts/truststore.jks /elasticsearch/config/truststore.jks
 
 # Set environment
 ENV NAMESPACE default

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,17 @@ MAINTAINER pjpires@gmail.com
 ADD do_not_use.yml /elasticsearch/config/elasticsearch.yml
 
 # Install Elasticsearch plug-ins
-RUN /elasticsearch/bin/plugin install io.fabric8/elasticsearch-cloud-kubernetes/2.4.1 --verbose
+RUN /elasticsearch/bin/plugin install io.fabric8/elasticsearch-cloud-kubernetes/2.4.1
+RUN /elasticsearch/bin/plugin install lmenezes/elasticsearch-kopf
+RUN /elasticsearch/bin/plugin install com.floragunn/search-guard-ssl/2.4.1.16
 
 # Override elasticsearch.yml config, otherwise plug-in install will fail
 ADD elasticsearch.yml /elasticsearch/config/elasticsearch.yml
+
+# Copy in SSL Certs
+# NOTE: For a Kubernetes based deployment, make these secrets which are provided dynamically
+ADD scripts/node-keystore.jks /elasticsearch/config/node-keystore.jks
+ADD scripts/truststore.jks /elasticsearch/config/truststore.jks
 
 # Set environment
 ENV NAMESPACE default

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # docker-elasticsearch-kubernetes
 
-Ready to use lean (146MB) Elasticsearch Docker image ready for using within a Kubernetes cluster.
+Ready to use lean (154MB) Elasticsearch Docker image ready for using within a Kubernetes cluster.
 
 [![Docker Repository on Quay.io](https://quay.io/repository/pires/docker-elasticsearch-kubernetes/status "Docker Repository on Quay.io")](https://quay.io/repository/pires/docker-elasticsearch-kubernetes)
 
 ## Current software
 
 * OpenJDK JRE 8u92
-* Elasticsearch 2.4.1
-* Kubernetes discovery plug-in 2.4.1
+* Elasticsearch 5.0.0
+* Kubernetes discovery plug-in 5.0.0
+* kopf elasticsearch web administration tool (https://github.com/lmenezes/elasticsearch-kopf)
+* Search Guard SSL for Elasticsearch (https://github.com/floragunncom/search-guard-ssl)
 
 ## Run
 
@@ -22,3 +24,7 @@ Besides the [inherited ones](https://github.com/pires/docker-elasticsearch#envir
 
 * [DISCOVERY_SERVICE](https://github.com/fabric8io/elasticsearch-cloud-kubernetes#kubernetes-pod-discovery)
 * [NAMESPACE](https://github.com/fabric8io/elasticsearch-cloud-kubernetes#kubernetes-pod-discovery)
+
+## TLS
+
+TLS is enabled by default in the image utilizing the Search Guard SSL for Elasticsearch by floragunn. To enable simply make some certs by running the `scripts/make-certs.sh` script before building. 

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -13,7 +13,9 @@ path:
   plugins: /elasticsearch/plugins
   work: /data/work
 
-bootstrap.mlockall: true
+bootstrap:
+  memory_lock: true
+  ignore_system_bootstrap_checks: true
 
 http:
   enabled: ${HTTP_ENABLE}
@@ -24,13 +26,30 @@ http:
 
 cloud:
   kubernetes:
-    service: ${DISCOVERY_SERVICE}
+    service: ${SERVICE}
     namespace: ${NAMESPACE}
 discovery:
   type: kubernetes
   zen:
     minimum_master_nodes: ${NUMBER_OF_MASTERS}
 
+plugin.mandatory: discovery-kubernetes
+
 index:
     number_of_shards: ${NUMBER_OF_SHARDS}
     number_of_replicas: ${NUMBER_OF_REPLICAS}
+
+searchguard:
+  ssl:
+    transport:
+      keystore_filepath: node-keystore.jks
+      keystore_password: changeit
+      truststore_filepath: truststore.jks
+      truststore_password: changeit
+      enforce_hostname_verification: false
+    http:
+      enabled: true
+      keystore_filepath: node-keystore.jks
+      keystore_password: changeit
+      truststore_filepath: truststore.jks
+      truststore_password: changeit

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -13,9 +13,7 @@ path:
   plugins: /elasticsearch/plugins
   work: /data/work
 
-bootstrap:
-  memory_lock: true
-  ignore_system_bootstrap_checks: true
+bootstrap.mlockall: true
 
 http:
   enabled: ${HTTP_ENABLE}
@@ -33,8 +31,6 @@ discovery:
   zen:
     minimum_master_nodes: ${NUMBER_OF_MASTERS}
 
-plugin.mandatory: discovery-kubernetes
-
 index:
     number_of_shards: ${NUMBER_OF_SHARDS}
     number_of_replicas: ${NUMBER_OF_REPLICAS}
@@ -42,14 +38,14 @@ index:
 searchguard:
   ssl:
     transport:
-      keystore_filepath: node-keystore.jks
+      keystore_filepath: certs/node-keystore.jks
       keystore_password: changeit
-      truststore_filepath: truststore.jks
+      truststore_filepath: certs/truststore.jks
       truststore_password: changeit
       enforce_hostname_verification: false
     http:
       enabled: true
-      keystore_filepath: node-keystore.jks
+      keystore_filepath: certs/node-keystore.jks
       keystore_password: changeit
-      truststore_filepath: truststore.jks
+      truststore_filepath: certs/truststore.jks
       truststore_password: changeit

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,7 @@
+ca/
+certs/
+crl/
+*.jks
+*.p12
+*.pem
+*.csr

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+rm -rf ca/
+rm -rf certs/
+rm -rf crl/
+rm -f *.jks
+rm -f *.pem
+rm -f *.p12
+rm -f *.csr

--- a/scripts/etc/root-ca.conf
+++ b/scripts/etc/root-ca.conf
@@ -1,0 +1,102 @@
+# Simple Root CA
+
+# The [default] section contains global constants that can be referred to from
+# the entire configuration file. It may also hold settings pertaining to more
+# than one openssl command.
+
+[ default ]
+ca                      = root-ca               # CA name
+dir                     = .                     # Top dir
+
+# The next part of the configuration file is used by the openssl req command.
+# It defines the CA's key pair, its DN, and the desired extensions for the CA
+# certificate.
+
+[ req ]
+default_bits            = 2048                  # RSA key size
+encrypt_key             = yes                   # Protect private key
+default_md              = sha256                # MD to use
+utf8                    = yes                   # Input is UTF-8
+string_mask             = utf8only              # Emit UTF-8 strings
+prompt                  = no                    # Don't prompt for DN
+distinguished_name      = ca_dn                 # DN section
+req_extensions          = ca_reqext             # Desired extensions
+
+[ ca_dn ]
+0.domainComponent       = "com"
+1.domainComponent       = "example"
+organizationName        = "Example Com Inc."
+organizationalUnitName  = "Example Com Inc. Root CA"
+commonName              = "Example Com Inc. Root CA"
+
+[ ca_reqext ]
+keyUsage                = critical,keyCertSign,cRLSign
+basicConstraints        = critical,CA:true
+subjectKeyIdentifier    = hash
+
+# The remainder of the configuration file is used by the openssl ca command.
+# The CA section defines the locations of CA assets, as well as the policies
+# applying to the CA.
+
+[ ca ]
+default_ca              = root_ca               # The default CA section
+
+[ root_ca ]
+certificate             = $dir/ca/$ca.crt       # The CA cert
+private_key             = $dir/ca/$ca/private/$ca.key # CA private key
+new_certs_dir           = $dir/ca/$ca           # Certificate archive
+serial                  = $dir/ca/$ca/db/$ca.crt.srl # Serial number file
+crlnumber               = $dir/ca/$ca/db/$ca.crl.srl # CRL number file
+database                = $dir/ca/$ca/db/$ca.db # Index file
+unique_subject          = no                    # Require unique subject
+default_days            = 3652                  # How long to certify for
+default_md              = sha256                 # MD to use
+policy                  = any_pol               # Default naming policy
+email_in_dn             = no                    # Add email to cert DN
+preserve                = no                    # Keep passed DN ordering
+name_opt                = ca_default            # Subject DN display options
+cert_opt                = ca_default            # Certificate display options
+copy_extensions         = copy                  # Copy extensions from CSR
+x509_extensions         = signing_ca_ext        # Default cert extensions
+default_crl_days        = 365                   # How long before next CRL
+crl_extensions          = crl_ext               # CRL extensions
+
+# Naming policies control which parts of a DN end up in the certificate and
+# under what circumstances certification should be denied.
+
+[ match_pol ]
+domainComponent         = match                 # Must match 'simple.org'
+organizationName        = match                 # Must match 'Simple Inc'
+organizationalUnitName  = optional              # Included if present
+commonName              = supplied              # Must be present
+
+[ any_pol ]
+domainComponent         = optional
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = optional
+emailAddress            = optional
+
+# Certificate extensions define what types of certificates the CA is able to
+# create.
+
+[ root_ca_ext ]
+keyUsage                = critical,keyCertSign,cRLSign
+basicConstraints        = critical,CA:true
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid:always
+
+[ signing_ca_ext ]
+keyUsage                = critical,keyCertSign,cRLSign
+basicConstraints        = critical,CA:true,pathlen:0
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid:always
+
+# CRL extensions exist solely to point to the CA certificate that has issued
+# the CRL.
+
+[ crl_ext ]
+authorityKeyIdentifier  = keyid:always

--- a/scripts/etc/signing-ca.conf
+++ b/scripts/etc/signing-ca.conf
@@ -1,0 +1,104 @@
+# Simple Signing CA
+
+# The [default] section contains global constants that can be referred to from
+# the entire configuration file. It may also hold settings pertaining to more
+# than one openssl command.
+
+[ default ]
+ca                      = signing-ca            # CA name
+dir                     = .                     # Top dir
+
+# The next part of the configuration file is used by the openssl req command.
+# It defines the CA's key pair, its DN, and the desired extensions for the CA
+# certificate.
+
+[ req ]
+default_bits            = 2048                  # RSA key size
+encrypt_key             = yes                   # Protect private key
+default_md              = sha256                # MD to use
+utf8                    = yes                   # Input is UTF-8
+string_mask             = utf8only              # Emit UTF-8 strings
+prompt                  = no                    # Don't prompt for DN
+distinguished_name      = ca_dn                 # DN section
+req_extensions          = ca_reqext             # Desired extensions
+
+[ ca_dn ]
+0.domainComponent       = "com"
+1.domainComponent       = "example"
+organizationName        = "Example Com Inc."
+organizationalUnitName  = "Example Com Inc. Signing CA"
+commonName              = "Example Com Inc. Signing CA"
+
+[ ca_reqext ]
+keyUsage                = critical,keyCertSign,cRLSign
+basicConstraints        = critical,CA:true,pathlen:0
+subjectKeyIdentifier    = hash
+
+# The remainder of the configuration file is used by the openssl ca command.
+# The CA section defines the locations of CA assets, as well as the policies
+# applying to the CA.
+
+[ ca ]
+default_ca              = signing_ca            # The default CA section
+
+[ signing_ca ]
+certificate             = $dir/ca/$ca.crt       # The CA cert
+private_key             = $dir/ca/$ca/private/$ca.key # CA private key
+new_certs_dir           = $dir/ca/$ca           # Certificate archive
+serial                  = $dir/ca/$ca/db/$ca.crt.srl # Serial number file
+crlnumber               = $dir/ca/$ca/db/$ca.crl.srl # CRL number file
+database                = $dir/ca/$ca/db/$ca.db # Index file
+unique_subject          = no                    # Require unique subject
+default_days            = 730                   # How long to certify for
+default_md              = sha256                # MD to use
+policy                  = any_pol               # Default naming policy
+email_in_dn             = no                    # Add email to cert DN
+preserve                = no                    # Keep passed DN ordering
+name_opt                = ca_default            # Subject DN display options
+cert_opt                = ca_default            # Certificate display options
+copy_extensions         = copy                  # Copy extensions from CSR
+x509_extensions         = client_ext             # Default cert extensions
+default_crl_days        = 7                     # How long before next CRL
+crl_extensions          = crl_ext               # CRL extensions
+
+# Naming policies control which parts of a DN end up in the certificate and
+# under what circumstances certification should be denied.
+
+[ match_pol ]
+domainComponent         = match                 # Must match 'simple.org'
+organizationName        = match                 # Must match 'Simple Inc'
+organizationalUnitName  = optional              # Included if present
+commonName              = supplied              # Must be present
+
+[ any_pol ]
+domainComponent         = optional
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = optional
+emailAddress            = optional
+
+# Certificate extensions define what types of certificates the CA is able to
+# create.
+
+[ client_ext ]
+keyUsage                = critical,digitalSignature,keyEncipherment
+basicConstraints        = CA:false
+extendedKeyUsage        = clientAuth
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid:always
+
+[ server_ext ]
+keyUsage                = critical,digitalSignature,keyEncipherment
+basicConstraints        = CA:false
+extendedKeyUsage        = serverAuth,clientAuth
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid:always
+
+# CRL extensions exist solely to point to the CA certificate that has issued
+# the CRL.
+
+[ crl_ext ]
+authorityKeyIdentifier  = keyid:always

--- a/scripts/gen_client_node_cert.sh
+++ b/scripts/gen_client_node_cert.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+CLIENT_NAME=$1
+
+if [ -z "$3" ] ; then
+  unset CA_PASS KS_PASS
+  read -p "Enter CA pass: " -s CA_PASS ; echo
+  read -p "Enter Keystore pass: " -s KS_PASS ; echo
+ else
+  KS_PASS=$2
+  CA_PASS=$3
+fi
+
+rm -f $CLIENT_NAME-keystore.jks
+rm -f $CLIENT_NAME.csr
+rm -f $CLIENT_NAME-signed.pem
+
+echo Generating keystore and certificate for node $CLIENT_NAME
+
+keytool -genkey \
+        -alias     $CLIENT_NAME \
+        -keystore  $CLIENT_NAME-keystore.jks \
+        -keyalg    RSA \
+        -keysize   2048 \
+        -sigalg SHA256withRSA \
+        -validity  712 \
+        -keypass $KS_PASS \
+        -storepass $KS_PASS \
+        -dname "CN=$CLIENT_NAME, OU=client, O=client, L=Test, C=DE"
+
+echo Generating certificate signing request for node $CLIENT_NAME
+
+keytool -certreq \
+        -alias      $CLIENT_NAME \
+        -keystore   $CLIENT_NAME-keystore.jks \
+        -file       $CLIENT_NAME.csr \
+        -keyalg     rsa \
+        -keypass $KS_PASS \
+        -storepass $KS_PASS \
+        -dname "CN=$CLIENT_NAME, OU=client, O=client, L=Test, C=DE"
+
+echo Sign certificate request with CA
+openssl ca \
+    -in $CLIENT_NAME.csr \
+    -notext \
+    -out $CLIENT_NAME-signed.pem \
+    -config etc/signing-ca.conf \
+    -extensions v3_req \
+    -batch \
+	-passin pass:$CA_PASS \
+	-extensions server_ext
+
+echo "Import back to keystore (including CA chain)"
+
+cat ca/chain-ca.pem $CLIENT_NAME-signed.pem | keytool \
+    -importcert \
+    -keystore $CLIENT_NAME-keystore.jks \
+    -storepass $KS_PASS \
+    -noprompt \
+    -alias $CLIENT_NAME
+
+keytool -importkeystore -srckeystore $CLIENT_NAME-keystore.jks -srcstorepass $KS_PASS -srcstoretype JKS -deststoretype PKCS12 -deststorepass $KS_PASS -destkeystore $CLIENT_NAME-keystore.p12
+
+openssl pkcs12 -in "$CLIENT_NAME-keystore.p12" -out "$CLIENT_NAME.all.pem" -nodes -passin "pass:$KS_PASS"
+openssl pkcs12 -in "$CLIENT_NAME-keystore.p12" -out "$CLIENT_NAME.key.pem" -nocerts -nodes -passin pass:$KS_PASS
+openssl pkcs12 -in "$CLIENT_NAME-keystore.p12" -out "$CLIENT_NAME.crt.pem" -clcerts -nokeys -passin pass:$KS_PASS
+cat "$CLIENT_NAME.crt.pem" ca/chain-ca.pem  > "$CLIENT_NAME.crtfull.pem"
+
+echo All done for $CLIENT_NAME
+	

--- a/scripts/gen_node_cert.sh
+++ b/scripts/gen_node_cert.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#########################
+# 'dname' and 'ext san' have to specified on two location in this file
+# For the meaning of oid:1.2.3.4.5.5 see:
+#    https://github.com/floragunncom/search-guard-docs/blob/master/architecture.md
+#    https://github.com/floragunncom/search-guard-docs/blob/master/installation.md
+#########################
+
+set -e
+NODE_NAME=node
+
+if [ -z "$3" ] ; then
+  unset CA_PASS KS_PASS
+  read -p "Enter CA pass: " -s CA_PASS ; echo
+  read -p "Enter Keystore pass: " -s KS_PASS ; echo
+ else
+  KS_PASS=$2
+  CA_PASS=$3
+fi
+
+rm -f $NODE_NAME-keystore.jks
+rm -f $NODE_NAME.csr
+rm -f $NODE_NAME-signed.pem
+
+echo Generating keystore and certificate for node $NODE_NAME
+
+keytool -genkey \
+        -alias     $NODE_NAME \
+        -keystore  $NODE_NAME-keystore.jks \
+        -keyalg    RSA \
+        -keysize   2048 \
+        -validity  712 \
+        -sigalg SHA256withRSA \
+        -keypass $KS_PASS \
+        -storepass $KS_PASS \
+        -dname "CN=$NODE_NAME.example.com, OU=SSL, O=Test, L=Test, C=DE" \
+        -ext san=dns:$NODE_NAME.example.com,dns:localhost,ip:127.0.0.1,oid:1.2.3.4.5.5
+
+#oid:1.2.3.4.5.5 denote this a server node certificate for search guard
+
+echo Generating certificate signing request for node $NODE_NAME
+
+keytool -certreq \
+        -alias      $NODE_NAME \
+        -keystore   $NODE_NAME-keystore.jks \
+        -file       $NODE_NAME.csr \
+        -keyalg     rsa \
+        -keypass $KS_PASS \
+        -storepass $KS_PASS \
+        -dname "CN=$NODE_NAME.example.com, OU=SSL, O=Test, L=Test, C=DE" \
+        -ext san=dns:$NODE_NAME.example.com,dns:localhost,ip:127.0.0.1,oid:1.2.3.4.5.5
+
+#oid:1.2.3.4.5.5 denote this a server node certificate for search guard
+
+echo Sign certificate request with CA
+openssl ca \
+    -in $NODE_NAME.csr \
+    -notext \
+    -out $NODE_NAME-signed.pem \
+    -config etc/signing-ca.conf \
+    -extensions v3_req \
+    -batch \
+	-passin pass:$CA_PASS \
+	-extensions server_ext
+
+echo "Import back to keystore (including CA chain)"
+
+cat ca/chain-ca.pem $NODE_NAME-signed.pem | keytool \
+    -importcert \
+    -keystore $NODE_NAME-keystore.jks \
+    -storepass $KS_PASS \
+    -noprompt \
+    -alias $NODE_NAME
+
+keytool -importkeystore -srckeystore $NODE_NAME-keystore.jks -srcstorepass $KS_PASS -srcstoretype JKS -deststoretype PKCS12 -deststorepass $KS_PASS -destkeystore $NODE_NAME-keystore.p12
+
+echo All done for $NODE_NAME

--- a/scripts/gen_root_ca.sh
+++ b/scripts/gen_root_ca.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Provided via https://raw.githubusercontent.com/floragunncom/search-guard-ssl/master/example-pki-scripts/gen_root_ca.sh
+set -e
+rm -rf ca certs* crl *.jks
+
+if [ -z "$2" ] ; then
+  unset CA_PASS TS_PASS
+  read -p "Enter CA pass: " -s CA_PASS ; echo
+  read -p "Enter Truststore pass: " -s TS_PASS ; echo
+ else
+  CA_PASS=$1
+  TS_PASS=$2
+fi
+
+mkdir -p ca/root-ca/private ca/root-ca/db crl certs
+chmod 700 ca/root-ca/private
+
+cp /dev/null ca/root-ca/db/root-ca.db
+cp /dev/null ca/root-ca/db/root-ca.db.attr
+echo 01 > ca/root-ca/db/root-ca.crt.srl
+echo 01 > ca/root-ca/db/root-ca.crl.srl
+
+openssl req -new \
+    -config etc/root-ca.conf \
+    -out ca/root-ca.csr \
+    -keyout ca/root-ca/private/root-ca.key \
+	-batch \
+	-passout pass:$CA_PASS
+
+
+openssl ca -selfsign \
+    -config etc/root-ca.conf \
+    -in ca/root-ca.csr \
+    -out ca/root-ca.crt \
+    -extensions root_ca_ext \
+	-batch \
+	-passin pass:$CA_PASS
+
+echo Root CA generated
+
+mkdir -p ca/signing-ca/private ca/signing-ca/db crl certs
+chmod 700 ca/signing-ca/private
+
+cp /dev/null ca/signing-ca/db/signing-ca.db
+cp /dev/null ca/signing-ca/db/signing-ca.db.attr
+echo 01 > ca/signing-ca/db/signing-ca.crt.srl
+echo 01 > ca/signing-ca/db/signing-ca.crl.srl
+
+openssl req -new \
+    -config etc/signing-ca.conf \
+    -out ca/signing-ca.csr \
+    -keyout ca/signing-ca/private/signing-ca.key \
+	-batch \
+	-passout pass:$CA_PASS
+
+openssl ca \
+    -config etc/root-ca.conf \
+    -in ca/signing-ca.csr \
+    -out ca/signing-ca.crt \
+    -extensions signing_ca_ext \
+	-batch \
+	-passin pass:$CA_PASS
+
+echo Signing CA generated
+
+openssl x509 -in ca/root-ca.crt -out ca/root-ca.pem -outform PEM
+openssl x509 -in ca/signing-ca.crt -out ca/signing-ca.pem -outform PEM
+cat ca/signing-ca.pem ca/root-ca.pem > ca/chain-ca.pem
+
+#http://stackoverflow.com/questions/652916/converting-a-java-keystore-into-pem-format
+
+cat ca/root-ca.pem | keytool \
+    -import \
+    -v \
+    -keystore truststore.jks   \
+    -storepass $TS_PASS  \
+    -noprompt -alias root-ca-chain

--- a/scripts/make-certs.sh
+++ b/scripts/make-certs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+./gen_root_ca.sh capass changeit
+./gen_node_cert.sh 0 changeit capass


### PR DESCRIPTION
This adds TLS to v2.4.1 using (https://github.com/floragunncom/search-guard-ssl). There is one breaking change, I'm working to have this work with the helm chart here (https://github.com/kubernetes/charts/tree/master/incubator/elasticsearch) which switches the discovery service env variable. 

Happy to discuss! I'm going to have a PR to the helm charts repo to allow this to work with it. 