### PR TITLE
Add support for ingest node flag

### DIFF
--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -4,6 +4,7 @@ cluster:
 node:
   master: ${NODE_MASTER}
   data: ${NODE_DATA}
+  ingest: ${NODE_INGEST}
 
 network.host: ${NETWORK_HOST}
 


### PR DESCRIPTION
ES 5.0.0 uses the "ingest" flag rather than the "client" flag ([see here](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html))

This provides support for this flag to be passed in as an ENV

I'll open a separate PR for the upstream repo as well.