### PR TITLE
force MEMORY_LOCK default to false.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,6 @@ ADD config /elasticsearch/config
 
 # Set environment
 ENV DISCOVERY_SERVICE elasticsearch-discovery
+
+# kubernetes runtime requires swap is turned off, so memory lock is redundant
+ENV MEMORY_LOCK false

--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ This image can be configured by means of environment variables, that one can set
 
 Besides the [inherited ones](https://github.com/pires/docker-elasticsearch#environment-variables), this container image provides the following:
 
-* `DISCOVERY_SERVICE` - the service to be queried for through DNS.
+* [DISCOVERY_SERVICE](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-zen.html#unicast) - the service to be queried for through DNS (default = `elasticsearch-discovery`).
+* [MEMORY_LOCK](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#bootstrap.memory_lock) - memory locking control defaults to `false` as Kubernetes requires swap to be disabled.

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -15,7 +15,7 @@ path:
   logs: /data/log
 
 bootstrap:
-  memory_lock: true
+  memory_lock: ${MEMORY_LOCK}
 
 http:
   enabled: ${HTTP_ENABLE}


### PR DESCRIPTION
Depends on pires/docker-elasticsearch#40 .
