### PR TITLE
Fix Entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ ENV DISCOVERY_SERVICE elasticsearch-discovery
 # Kubernetes requires swap is turned off, so memory lock is redundant
 ENV MEMORY_LOCK false
 
-COPY entrypoint.sh /
-ENTRYPOINT ["/entrypoint.sh"]
+RUN mv /run.sh /run1.sh
+COPY run.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ADD config /elasticsearch/config
 
 # Set environment
 ENV DISCOVERY_SERVICE elasticsearch-discovery
+ENV REPO_LOCATIONS []
 
 # Kubernetes requires swap is turned off, so memory lock is redundant
 ENV MEMORY_LOCK false

--- a/README.md
+++ b/README.md
@@ -23,3 +23,21 @@ Besides the [inherited ones](https://github.com/pires/docker-elasticsearch#envir
 * [MEMORY_LOCK](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#bootstrap.memory_lock) - memory locking control defaults to `false` as Kubernetes requires swap to be disabled.
 * MY_MEM_LIMIT, MY_MEM_REQUEST  - These should be set to the container's Kubernetes memory limit and memory request values using the [Downward API ](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-container-fields-as-values-for-environment-variables). This allows the image to automatically set the JVM heap size to a value relative to the containers limits. By default it will configure the JVM heap size to 50% of the pod's memory limit, or memory request if limit is not set. It will only set the JVM heapsize if the `-Xmx` flag is not already passed via `$JVM_JAVA_OPTS`.
 * OVERWRITE_JVM_HEAPSIZE - Set to true to ensure heapsize is set based on MY_MEM_LIMIT or MY_MEM_REQUEST rather than using the default in the docker image.
+* [REPO_LOCATIONS](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html#_shared_file_system_repository) - list of registered repository locations. For example `["/backup"]` (default = `[]`).
+
+## Backup
+Mount a shared folder (for example via NFS) to `/backup`, make sure the `elasticsearch` user of the container has write access, set the `REPO_LOCATIONS` environment variable to `["/backup"]` and create a backup repository:
+
+`backup_repository.json`:
+
+      {
+        "type": "fs",
+        "settings": {
+          "location": "/backup",
+          "compress": true
+        }
+      }
+
+Upload it to the server: `curl -XPOST http://localhost:9200/_snapshot/nas_repository -d @backup_repository.json`. Now you can take snapshots using
+
+    curl -f -XPUT "http://localhost:9200/_snapshot/nas_repository/snapshot_`date --utc +%Y_%m_%dt%H_%M`?wait_for_completion=true"

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -13,6 +13,7 @@ network.host: ${NETWORK_HOST}
 path:
   data: /data/data
   logs: /data/log
+  repo: ${REPO_LOCATIONS}
 
 bootstrap:
   memory_lock: ${MEMORY_LOCK}

--- a/run.sh
+++ b/run.sh
@@ -43,4 +43,4 @@ set_set_es_java_opts() {
 }
 
 set_set_es_java_opts
-exec "$@"
+exec /run1.sh "$@"


### PR DESCRIPTION
The change introduced to automatically set the JVM heap size introduced a regression: It was not possible to start the container with just `docker run --privileged quay/.../.../elasticsearch`. You needed to always include `/run.sh` as argument. 

I removed the entrypoint and replaced it with a combined `/run.sh` script.