### PR TITLE
Adding reindex.remote.whitelist config option

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -33,3 +33,5 @@ discovery:
     minimum_master_nodes: ${NUMBER_OF_MASTERS}
 
 xpack.ml.enabled: false
+
+reindex.remote.whitelist: ${REINDEX_REMOTE_WHITELIST}


### PR DESCRIPTION
I would love to add this in so we can set up reindex much more easily between clusters.